### PR TITLE
Updated index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ FibaroHC2Platform.prototype = {
   					accessory.platform 			= that;
 				  	accessory.remoteAccessory	= s;
   					accessory.id 				= s.id;
+  					accessory.uuid_base			= s.id;
   					accessory.name				= s.name;
   					accessory.model				= s.type;
   					accessory.manufacturer		= "Fibaro";


### PR DESCRIPTION
Updated homebridge-fibaro-hc2 to work without the requirement of having unique names. I had the problems that I had the same name in different rooms for the same accessory e.g. the name 'ceiling lamp' in the "kitchen" AND the "working room". Also I changed my names during setup due to suggestions my wife was making (which where always better than my technical terms :smile: ) 

The homebridge project changed with v0.2.8 to use a 'uuid_base' property on the accesory instance (when available) and only if that uuid_base property is not set, it uses the displayName instead.



so this additional line enables to use the same name of multiple devices AND it enables to change the name of the device without losing it in the dedicated homekit app using the homebridge