### PR TITLE
fix open state at 99% for blinds.

### DIFF
--- a/index.js
+++ b/index.js
@@ -412,9 +412,10 @@ FibaroHC2Platform.prototype.getAccessoryValue = function(callback, returnBoolean
 				callback(undefined, properties.value == "true" ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED);
 			} else if (characteristic.UUID == (new Characteristic.CurrentPosition()).UUID || characteristic.UUID == (new Characteristic.TargetPosition()).UUID) {
 				var v = parseInt(properties.value);
-				if (v >= characteristic.props.minValue && v <= characteristic.props.maxValue)
+				if (v >= characteristic.props.minValue && v <= characteristic.props.maxValue) {
+					if (v == 99) v = 100;
 					callback(undefined, v);
-				else {
+				} else {
 					that.log("There was a problem getting value for blind" + IDs[0] + ", value = " + v);
 					callback("Error value window position", null);
 				}
@@ -483,6 +484,7 @@ FibaroHC2Platform.prototype.startPollingUpdate = function() {
 									subscription.characteristic.setValue(value == true ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED, undefined, 'fromFibaro');
 								else if (subscription.characteristic.UUID == (new Characteristic.CurrentPosition()).UUID || subscription.characteristic.UUID == (new Characteristic.TargetPosition()).UUID) {
 									if (value >= subscription.characteristic.props.minValue && value <= subscription.characteristic.props.maxValue) {
+										if (value == 99) value = 100;
 										subscription.characteristic.setValue(value, undefined, 'fromFibaro');
 									}
 								} else if (s.power != undefined && powerValue) {


### PR DESCRIPTION
I just got my automated blinds installed and have hooked them up with fibaro blind modules.
They seems to have the same issue as the dimmer did - where the home center api returns 99 for a device when it's fully open. 
Then the home app gets stuck on "opening" the device as it never gets to 100%. If you quit and restart the home app, it then reports the device 99% open.

```
{
		"id": 279,
		"name": "Master Blind 2",
		"roomID": 5,
		"type": "com.fibaro.FGRM222",
		"baseType": "com.fibaro.FGR221",
		"enabled": true,
		"visible": true,
		"isPlugin": false,
		"parentId": 278,
		"remoteGatewayId": 0,
		"viewXml": false,
		"configXml": false,
		"interfaces": [
			"energy",
			"levelChange",
			"power",
			"zwave",
			"zwaveMultiChannelAssociation",
			"zwaveProtection",
			"zwaveSceneActivation"
		],
		"properties": {
			"zwaveCompany": "Fibargroup",
			"zwaveInfo": "3,3,52",
			"zwaveVersion": "25.25",
			"pollingTimeSec": 0,
			"RFProtectionState": "0",
			"RFProtectionSupport": "3",
			"configured": "true",
			"dead": "false",
			"deviceControlType": "54",
			"deviceIcon": "87",
			"emailNotificationID": "0",
			"emailNotificationType": "0",
			"endPointId": "0",
			"energy": "0.01",
			"liliOffCommand": "",
			"liliOnCommand": "",
			"localProtectionState": "0",
			"localProtectionSupport": "5",
			"log": "",
			"logTemp": "",
			"manufacturer": "",
			"markAsDead": "true",
			"model": "",
			"nodeId": "62",
			"parametersTemplate": "721",
			"power": "0.00",
			"productInfo": "1,15,3,2,48,0,25,25",
			"protectionExclusiveControl": "0",
			"protectionExclusiveControlSupport": "false",
			"protectionLocal": "0",
			"protectionLocalSupport": "5",
			"protectionRF": "0",
			"protectionRFSupport": "3",
			"protectionState": "0",
			"protectionTimeout": "0",
			"protectionTimeoutSupport": "false",
			"pushNotificationID": "0",
			"pushNotificationType": "0",
			"remoteGatewayId": "0",
			"saveLogs": "true",
			"sceneActivation": "0",
			"serialNumber": "",
			"showEnergy": "true",
			"smsNotificationID": "0",
			"smsNotificationType": "0",
			"useTemplate": "true",
			"userDescription": "",
			"value": "99"
		},
		"actions": {
			"close": 0,
			"open": 0,
			"reconfigure": 0,
			"reset": 0,
			"setValue": 1,
			"setValue2": 1,
			"startLevelDecrease": 0,
			"startLevelIncrease": 0,
			"stop": 0,
			"stopLevelChange": 0
		},
		"created": 1471309362,
		"modified": 1471309362,
		"sortOrder": 39
	},
```

This patch solves the problem for me, allowing tap to open or close, as well as sliding to choose a particular position.