### PR TITLE
Save Fibaro device name in SerialNumber to identify device

### DIFF
--- a/dist/shadows.js
+++ b/dist/shadows.js
@@ -43,7 +43,7 @@ class ShadowAccessory {
         this.accessory.getService(this.hapService.AccessoryInformation)
             .setCharacteristic(this.hapCharacteristic.Manufacturer, "IlCato")
             .setCharacteristic(this.hapCharacteristic.Model, "HomeCenterBridgedAccessory")
-            .setCharacteristic(this.hapCharacteristic.SerialNumber, "<unknown>");
+            .setCharacteristic(this.hapCharacteristic.SerialNumber, this.name);
     }
     removeNoMoreExistingServices() {
         for (let t = 0; t < this.accessory.services.length; t++) {


### PR DESCRIPTION
Fibaro saves the device ID in the default device name. In HomeKit this name is usually replaced by a more speaking name, often same name for same type of device in different rooms, like "ceiling lamp". Renamed to same same names the relation to the respective Fibaro device is only maintained by the room the device is in. If the room is messed up by mistake, it is hard to figure out the related Fibaro device again. Saving the Fibaro device name in the SerialNumber solves this issue. This SerialNumber is visible in the HomeKit device properties. 

(I hope I figured out the right change for that.)