### PR TITLE
Bugfix: TypeError: Cannot read property 'zwaveCompany' of undefined

### DIFF
--- a/src/shadows.ts
+++ b/src/shadows.ts
@@ -61,12 +61,13 @@ export class ShadowAccessory {
 	}
 
 	initAccessory() {
-		let manufacturer = (this.device.properties.zwaveCompany || "IlCato").replace("Fibargroup", "Fibar Group");
+		const properties = this.device.properties || {}:
+		const manufacturer = (properties.zwaveCompany || "IlCato").replace("Fibargroup", "Fibar Group");
 		this.accessory.getService(this.hapService.AccessoryInformation)
 			.setCharacteristic(this.hapCharacteristic.Manufacturer, manufacturer)
 			.setCharacteristic(this.hapCharacteristic.Model, `${this.device.type || "HomeCenterBridgedAccessory"}`)
-			.setCharacteristic(this.hapCharacteristic.SerialNumber, `${this.device.properties.serialNumber || "<unknown>"}`)
-			.setCharacteristic(this.hapCharacteristic.FirmwareRevision, this.device.properties.zwaveVersion);
+			.setCharacteristic(this.hapCharacteristic.SerialNumber, `${properties.serialNumber || "<unknown>"}`)
+			.setCharacteristic(this.hapCharacteristic.FirmwareRevision, properties.zwaveVersion);
 	}
   	removeNoMoreExistingServices() {
 		for (let t = 0; t < this.accessory.services.length; t++) {


### PR DESCRIPTION
When defining virtual devices (such as global variables) in HC2 and exposing them via this plugin, the newest version would throw the following error:

```
[5/26/2019, 11:14:16 AM] [FibaroHC2] Error getting data from Home Center:  TypeError: Cannot read property 'zwaveCompany' of undefined
    at ShadowAccessory.initAccessory (/homebridge/node_modules/homebridge-fibaro-hc2/dist/shadows.js:44:52)
    at FibaroHC2.addAccessory (/homebridge/node_modules/homebridge-fibaro-hc2/dist/index.js:190:25)
    at FibaroHC2.LoadAccessories (/homebridge/node_modules/homebridge-fibaro-hc2/dist/index.js:157:22)
    at fibaroClient.getScenes.then.then (/homebridge/node_modules/homebridge-fibaro-hc2/dist/index.js:103:18)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:583) UnhandledPromiseRejectionWarning: Error: Startup error: get scenes or devices
    at fibaroClient.getScenes.then.then.catch (/homebridge/node_modules/homebridge-fibaro-hc2/dist/index.js:107:19)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:583) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:583) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

My proposed solution is to have an empty fallback-object that would make sure the defaults are used instead of throwing an error.