### PR TITLE
Show the temperature of an associated temp sensor if available

### DIFF
--- a/src/getFunctions.ts
+++ b/src/getFunctions.ts
@@ -100,7 +100,20 @@ export class GetFunctions {
 	// Float getter
 	getFloat(callback, characteristic, service, IDs, properties) {
 		let r = parseFloat(properties.value);
-		this.returnValue(r, callback, characteristic);
+
+		if(service.floatServiceId) {
+			this.platform.fibaroClient.getDeviceProperties(service.floatServiceId)
+			.then((properties) => {
+				r = parseFloat(properties.value);
+				this.returnValue(r, callback, characteristic);
+			})
+			.catch((err) => {
+				console.log("There was a problem getting value from: ", `${service.floatServiceId} - Err: ${err}` );
+				callback(err, null);
+			});
+		} else {
+			this.returnValue(r, callback, characteristic);
+		}
 	}
 	getBrightness(callback, characteristic, service, IDs, properties) {
 		let r;

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ class FibaroHC2 {
 		for (let s = 0; s < accessory.services.length; s++) {
 			let service = accessory.services[s];
 			if (service.subtype != undefined) {
-				let subtypeParams = service.subtype.split("-"); // DEVICE_ID-VIRTUAL_BUTTON_ID-RGB_MARKER-OPERATING_MODE_ID
+				let subtypeParams = service.subtype.split("-"); // DEVICE_ID-VIRTUAL_BUTTON_ID-RGB_MARKER-OPERATING_MODE_ID-FLOAT_SVC_ID
 				if (subtypeParams.length >= 3 && subtypeParams[2] == "RGB") {
 					// For RGB devices add specific attributes for managing it
 					service.HSBValue = {hue: 0, saturation: 0, brightness: 0};
@@ -174,6 +174,9 @@ class FibaroHC2 {
 				}
 				if (subtypeParams.length >= 4) {
 					service.operatingModeId = subtypeParams[3];
+				}
+				if (subtypeParams.length >= 5) {
+					service.floatServiceId = subtypeParams[4];
 				}
 			}
 			for (let i = 0; i < service.characteristics.length; i++) {

--- a/src/shadows.ts
+++ b/src/shadows.ts
@@ -233,7 +233,13 @@ export class ShadowAccessory {
 				let m = siblings.get("com.fibaro.operatingMode");
 				if (m) {
 					controlService.operatingModeId = m.id;
-					controlService.subtype = device.id + "---" + m.id;		
+					controlService.subtype = device.id + "---" + m.id;
+				}
+				// Check if there's a temperature Sensor and use it instead of the provided float value
+				let t = siblings.get("com.fibaro.temperatureSensor");
+				if(t) {
+					controlService.floatServiceId = t.id;
+					controlService.subtype = (controlService.subtype || device.id + "----") + t.id;
 				}
 				ss = [new ShadowService(controlService, controlCharacteristics)];
 				break;


### PR DESCRIPTION
This PR introduces a new feature: the ability to override the `getFloat` function so that it returns the `value` of a different service. This is then used to override the `Current Temperature` reading for Thermostats, should there be an associated Temperature Sensor.

The rationale for this is simple: I'm using thermostats that the HC exposes as several devices - the `com.fibaro.setPoint` (which will **always** have `properties.value === properties.targetLevel`) and a `com.fibaro.temperatureSensor` (which will report the actual temperature measured by the thermostat).

Until now, I've always seen this (note the `Current Temperature`):
![image](https://user-images.githubusercontent.com/1755213/61866719-f8fb5a00-aed5-11e9-9992-446107c01550.png)

With the PR, this changes to the following - correct - reading:
![image](https://user-images.githubusercontent.com/1755213/61866749-09133980-aed6-11e9-8d77-708ee8a0d09b.png)

I realise that using the `subtype` with so many different meanings is not optimal, yet I'm sure this would need to be reworked in a dedicated PR :-)
What do you think?