### PR TITLE
Fix for blind with positioning inactive

### DIFF
--- a/src/shadows.ts
+++ b/src/shadows.ts
@@ -178,7 +178,8 @@ export class ShadowAccessory {
 					hapCharacteristic.TargetPosition,
 					hapCharacteristic.PositionState
 				];
-				if (device.actions.setValue2 == 1) {
+				//if (device.actions.setValue2 == 1) {
+				if (device.properties.deviceControlType == 54) {
 					controlCharacteristics.push(
 						hapCharacteristic.CurrentHorizontalTiltAngle,
 						hapCharacteristic.TargetHorizontalTiltAngle


### PR DESCRIPTION
Table for shutter module type:

- value="53" --> Blind with positioning inactive
- value="54" --> Blind with positioning active
- value="55" --> Venetian blind
- value="56" --> Garage Door without positioning
- value="57" --> Garage Door with positioning